### PR TITLE
Demo embed staging URL

### DIFF
--- a/demo-embed.html
+++ b/demo-embed.html
@@ -1,0 +1,12 @@
+---
+title: Demo Gobierto Embed
+permalink: "/demo-embed/"
+layout: default
+---
+
+<script type="text/javascript" src="https://alcobendas.gobify.net/embed.js"></script>
+{% if jekyll.environment == "production" %}
+<div gobierto-embed="https://alcobendas.gobify.net/agendas" base-path="https://gobierto.es/demo-embed/"></div>
+{% elsif jekyll.environment == "development" %}
+<div gobierto-embed="http://madrid.gobierto.test/agendas" base-path="http://localhost:4000/demo-embed/"></div>
+{% endif %}


### PR DESCRIPTION
This PR creates a temporary demo-embed page. Temporary because we are linking to staging while we finish the implementation, it should show a production site once the embed has been deployed to production