### PR TITLE
Remove identity

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -46,18 +46,4 @@
   <meta name="msapplication-TileColor" content="#da532c">
   <meta name="msapplication-TileImage" content="{% asset 'favicons/mstile-144x144.png' @path %}">
   <meta name="theme-color" content="#A33A00">
-  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-  <script>
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", function () {
-        netlifyIdentity.init({
-          APIUrl: "https://gobierto-blog.netlify.app/.netlify/identity"
-        });
-      });
-    } else {
-      netlifyIdentity.init({
-        APIUrl: "https://gobierto-blog.netlify.app/.netlify/identity"
-      });
-    }
-  </script>
 </head>

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,8 +2,8 @@
 backend:
   name: git-gateway
   repo: PopulateTools/gobierto.es
-  identity_url: 'https://gobierto-blog.netlify.app/.netlify/identity'
-  gateway_url: 'https://gobierto-blog.netlify.app/.netlify/git'
+  identity_url: 'http://gobierto-blog.netlify.app/.netlify/identity'
+  gateway_url: 'http://gobierto-blog.netlify.app/.netlify/git'
   branch: master
 local_backend: true
 media_folder: /_assets/images/posts

--- a/admin/index.html
+++ b/admin/index.html
@@ -13,12 +13,12 @@
       if (document.readyState === "loading") {
         document.addEventListener("DOMContentLoaded", function () {
           netlifyIdentity.init({
-            APIUrl: "https://gobierto-blog.netlify.app/.netlify/identity"
+            APIUrl: "http://gobierto-blog.netlify.app/.netlify/identity"
           });
         });
       } else {
         netlifyIdentity.init({
-          APIUrl: "https://gobierto-blog.netlify.app/.netlify/identity"
+          APIUrl: "http://gobierto-blog.netlify.app/.netlify/identity"
         });
       }
     </script>

--- a/index.html
+++ b/index.html
@@ -1,7 +1,6 @@
 ---
 layout: default
 ---
-
 <div class="xl:max-w-screen-xl mx-auto p-8 pt-32 md:pt-0 md:p-0 lg:p-0 md:flex items-center items-stretch">
 
   <div class="lg:w-2/3 md:pl-16 md:pr-16 lg:pr-32 xl:pr-64">
@@ -170,15 +169,4 @@ document.addEventListener("DOMContentLoaded", function() {
     }, 2000 * i);
   }
 });
-</script>
-<script>
-  if (window.netlifyIdentity) {
-    window.netlifyIdentity.on("init", user => {
-      if (!user) {
-        window.netlifyIdentity.on("login", () => {
-          document.location.href = "/admin/";
-        });
-      }
-    });
-  }
 </script>


### PR DESCRIPTION
Remove identity to prevent errors with confirmation emails.
Use HTTP on the Identity endpoint instead of HTTPS.